### PR TITLE
Use named exports for debino

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Considering the following example:
 
 ```js
 // example.js
-import debino from '@uphold/debino';
+import { debino } from '@uphold/debino';
 
 const child1 = debino('foo');
 const child2 = debino('foo:bar');
@@ -74,7 +74,7 @@ You may also set the log level via the `LOG_LEVEL` environment variable. However
 Every call to `debino` creates a child logger based on a root logger. The default root logger is an instance returned by `pino()`, without any options. You may set your own root logger by calling `setRootLogger()`:
 
 ```js
-import debino, { pino, setRootLogger } from '@uphold/debino';
+import { debino, pino, setRootLogger } from '@uphold/debino';
 
 // Call this as soon as possible in your application.
 setRootLogger(pino({ redact: ['foo'] }));

--- a/src/index.js
+++ b/src/index.js
@@ -83,6 +83,6 @@ setRootLogger(pino());
  * Exports.
  */
 
-module.exports = debino;
+module.exports.debino = debino;
 module.exports.pino = pino;
 module.exports.setRootLogger = setRootLogger;

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -3,9 +3,8 @@
  */
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import debino, { setRootLogger } from '.';
+import { debino, pino, setRootLogger } from '.';
 import debug from 'debug';
-import pino, { symbols } from 'pino';
 
 /**
  * Tests for `debino()`.
@@ -29,7 +28,7 @@ describe('debino', () => {
 
     const logger = debino('biz', { serializers });
 
-    expect(logger[symbols.serializersSym].foo).toBe(serializers.foo);
+    expect(logger[pino.symbols.serializersSym].foo).toBe(serializers.foo);
   });
 
   it('should return the same logger instance for the same namespace', () => {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4,5 +4,4 @@ declare function debino(namespace: string, options?: { prefix?: string, suffix?:
 
 declare function setRootLogger(logger: Logger)
 
-export default debino;
-export { setRootLogger, pino }
+export { debino, pino, setRootLogger }


### PR DESCRIPTION
For improved usage, especially for CJS.
