### PR TITLE
Set the default child logger level to inherit from the root logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,10 +68,12 @@ const logger = debino('root')('foo', { level: 'info' });
 ```
 
 You may also set the log level via the `LOG_LEVEL` environment variable. However, the `level` option will always take precedence over it.
+If both `level` and `LOG_LEVEL` are not set, it will use the value from
+the root logger (See the [Root Logger](#root-logger) section below for more information).
 
 ### Root logger
 
-Every call to `debino` creates a child logger based on a root logger. The default root logger is an instance returned by `pino()`, without any options. You may set your own root logger by calling `setRootLogger()`:
+Every call to `debino` creates a child logger based on a root logger. The default root logger is an instance returned by `pino({ level: 'debug' })`. You may set your own root logger by calling `setRootLogger()`:
 
 ```js
 import { debino, pino, setRootLogger } from '@uphold/debino';

--- a/src/index.js
+++ b/src/index.js
@@ -55,7 +55,7 @@ const debino = (namespace, { prefix = 'sub', suffix = 'component', ...options } 
 
   // Ensure the root logger is set.
   if (!rootLogger) {
-    rootLogger = global[globalSymbol].rootLogger = pino();
+    rootLogger = global[globalSymbol].rootLogger = pino({ level: 'debug' });
   }
 
   // Create the logger for this namespace if it doesn't exist.
@@ -68,7 +68,7 @@ const debino = (namespace, { prefix = 'sub', suffix = 'component', ...options } 
 
   // Set the log level based on the debug namespace.
   if (debug.enabled(namespace)) {
-    childLogger.level = options.level ?? process.env.LOG_LEVEL ?? 'debug';
+    childLogger.level = options.level ?? process.env.LOG_LEVEL ?? rootLogger.level;
   } else {
     childLogger.level = 'silent';
   }

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -74,6 +74,15 @@ describe('debino', () => {
     expect(logger.level).toEqual('warn');
   });
 
+  it('should be on the specified level on the root logger if `DEBUG` matches logger name', () => {
+    debug.enable('abc');
+    setRootLogger(pino({ level: 'warn' }));
+
+    const logger = debino('abc');
+
+    expect(logger.level).toEqual('warn');
+  });
+
   it('should support multiple components separated by colons', () => {
     const logger = debino('foo:bar:biz:qux');
     const bindings = logger.bindings();


### PR DESCRIPTION
This sets the default child logger level to inherit from the root logger. To maintain backwards compatibility, the default root logger is now instantiated with `{ level: 'debug' }` when one was not provided through `setRootLogger`.